### PR TITLE
Feature/timer gps

### DIFF
--- a/.settings/language.settings.xml
+++ b/.settings/language.settings.xml
@@ -4,7 +4,7 @@
 		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider class="org.eclipse.cdt.managedbuilder.language.settings.providers.GCCBuildCommandParser" id="com.crt.advproject.GCCBuildCommandParser" keep-relative-paths="false" name="MCU GCC Build Output Parser" parameter="(arm-none-eabi-gcc)|(arm-none-eabi-[gc]\+\+)|(gcc)|([gc]\+\+)|(clang)" prefer-non-shared="true"/>
-			<provider class="com.crt.advproject.specs.MCUGCCBuiltinSpecsDetector" console="false" env-hash="493442545890829910" id="com.crt.advproject.GCCBuildSpecCompilerParser" keep-relative-paths="false" name="MCU GCC Built-in Compiler Parser" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="com.crt.advproject.specs.MCUGCCBuiltinSpecsDetector" console="false" env-hash="-1177878944100346863" id="com.crt.advproject.GCCBuildSpecCompilerParser" keep-relative-paths="false" name="MCU GCC Built-in Compiler Parser" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>
@@ -15,7 +15,7 @@
 		<extension point="org.eclipse.cdt.core.LanguageSettingsProvider">
 			<provider copy-of="extension" id="org.eclipse.cdt.ui.UserLanguageSettingsProvider"/>
 			<provider copy-of="extension" id="com.crt.advproject.GCCBuildCommandParser"/>
-			<provider class="com.crt.advproject.specs.MCUGCCBuiltinSpecsDetector" console="false" env-hash="496955031838258870" id="com.crt.advproject.GCCBuildSpecCompilerParser" keep-relative-paths="false" name="MCU GCC Built-in Compiler Parser" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
+			<provider class="com.crt.advproject.specs.MCUGCCBuiltinSpecsDetector" console="false" env-hash="-1174366458152917903" id="com.crt.advproject.GCCBuildSpecCompilerParser" keep-relative-paths="false" name="MCU GCC Built-in Compiler Parser" parameter="${COMMAND} ${FLAGS} -E -P -v -dD &quot;${INPUTS}&quot;" prefer-non-shared="true">
 				<language-scope id="org.eclipse.cdt.core.gcc"/>
 				<language-scope id="org.eclipse.cdt.core.g++"/>
 			</provider>

--- a/doc/m01_debug_if.md
+++ b/doc/m01_debug_if.md
@@ -49,11 +49,13 @@ where
 | ‘w’     | \<c\>\<adr\>\<b\>\<len\>  | writes the data byte \<b\> for \<len\> times starting at \<adr\> of mram chip number \<c\> (0...5).              |
 | 'p'     | \<abcd\|ABCD\>            | powers on or off one or more sidepanels. e.g "p ABcD" powers 3 of the 4 sidepanels. Blue LED shows on and goes off if current limiter detects short circuit | 
 | ‘O’     | \<name\>                  | sets the hardware instance name                                                                                  |
-| 'N'     | \<name\>                  | sets the sd-card name                                                                                  |
-| 'i'     | \-                        | gives general information about obc board, versions, ....
+| 'N'     | \<name\>                  | sets the sd-card name                                                                                            |
+| 'i'     | \-                        | gives general information about obc board, versions, ....                                                        |
+| 'T'     | \-                        | gives the current UTC time in RTC and TLE (juliandayfraction) format                                             |
+| 't'     | \<date\> \<time\>         | sets the UTC time to d´the given date / time. Format: yyyyMMdd hhmmss                                            |
 | ---     | ---                       | ---                                                                                                              |
 | 'h'     | \<pinIdx\> \<mode\>       | sets an GPIO pin to mode (0: initVal, 1: high, 2: low, 3: slow blink, 4: fast osz.)                              |
-| 'm'     | \<pinIdxIn\> [\<pinIdxOut\>] | mirrors the GPI input pin to the GPIO output pin 																 |
+| 'm'     | \<pinIdxIn\> [\<pinIdxOut\>] | mirrors the GPI input pin to the GPIO output pin 															 |
 
 Valid pinIdx for command 'h' and 'm' can be found in the hardware abstraction include file in source code..... 
 
@@ -110,4 +112,10 @@ where
 |                    |   [3]   | temperature (LM19) in °C   |
 |                    |   [4]   | temperature (SHT3X) in °C  |
 |                    |   [5]   | humidity in %   			|
+|--------------------|---------|----------------------------|
+| 0x01 / 0x03        |         | UTC time was synchronized  |
+|                    | uint32  | current reset number       |
+|                    | double  | old UTC Offset             |
+|                    | double  | new UTC Offset             |
+|                    | byte    | Sync Source (1 GPS, 2 Cmd, 3 RTC) |
 |--------------------|---------|----------------------------|

--- a/doc/m03_systime.md
+++ b/doc/m03_systime.md
@@ -1,0 +1,56 @@
+OBC Timestamps/RTC and related time formats
+===========================================
+
+systime
+-------
+
+is counted in ms after reset. This counter is counted by IRQ and never changed or adjusted by any other means. So it can be used as continuous timestamp with unsigned 32 bit size. 
+This gives a timestamp which runs without overrun for almost 50 days of operation without reset. 
+
+To get a unique mission timestamp which will 'never' repeat itself one have to additionally store the current reset counter (and somehow trigger a reset at least all 49 days).
+The Reset counter is also a 32bit unsigned counter and gets persisted in both the RTC general purpose registers (this are battery backuped during resets)
+and separately in all 6 MRAM chips available on the OBC board. With this we can guarantee that a systime together with the reset counter is a unique and non-repeatable timestamp.
+
+
+UTC time
+--------
+
+In order to get a valid UTC time - needed for operation and orbit prediction - there has to be some synchronization from the OBC outside world.
+Synchronization can be done by 
+- GPS connected to OBC (by UART RX and/or TX + PPS signal)
+- reception of a Sync command (either by radio transmission from ground station or from connected equipment on the debug/umbilical UART.
+
+Another source of synchronization can be the battery buffered on board RTC of the OBC. This can survive up to 10 minutes and will be good enough to resynchronize the UTC time after short resets without longer power loss.
+
+
+Precision and accuracy
+-----------------------
+
+systime is driven by the XTAL of the LPC1769.
+onboard RTC is driven by separate RTC quartz.
+GPS can be connected with additional PPS (pulse per second). This will be highest precision of synchronization, once this signal gets processed with a GPIO-Interrupt routine.
+
+all accuracy and temp dependent drifts and offsets have to be investigated in more detail and incorporated in later software versions.
+
+
+
+time date and timestamp formats
+-------------------------------
+
+obc_time module has the function timGetSystime() which delivers current ms after reset as obc_systime33_t (an alias for uint32_t).
+
+To get the UTC time (if synchronized) the function timGetUTCTime() can be used. It gives a
+obc_utc_fulltime_t 	structure containing following members:
+
+	uint32_t	 		rtcDate;		// UTC Date in format YYYYMMDD	(direct from hardware RTC)
+	uint32_t	 		rtcTime;		// UTC Time in format HHMMSS	(direct from hardware RTC)
+	juliandayfraction	tleDay;			// UTC Time in TLE dayOfYear format (calculated from XTAL Systime and last UTC Sync command)
+	double				currentDiff;    // in Seconds. The drift of XTAL Clock vs RTC since last Sync command. 
+
+
+ juliandayfraction is a double which follows the 'EPOCH' definition of the 'Field 8 in Line 1' of a TLE orbital elements definition used by https://celestrak.com/ (see also: https://en.wikipedia.org/wiki/Two-line_element_set )
+ The integer part is the day of the year and the remaining part is fractional portion of the day (0.5 -> 12:00 noon)     
+
+
+
+ 

--- a/doc/m90_apendix_a.md
+++ b/doc/m90_apendix_a.md
@@ -48,5 +48,6 @@ Decision of not using available RTOS implementation for LPC1769 based on
 - complexity added for development and debugging ( another hurdle for students new to embedded software dev)
 
 Reconsider if
-- own solution gets to comlex and/or also introduces comparable overhead.
+- own solution gets to complex and/or also introduces comparable overhead.
+- reuse of available other solutions (based on RTOS). 
 

--- a/src/mod/l7_climb_app.c
+++ b/src/mod/l7_climb_app.c
@@ -170,7 +170,7 @@ void SpPowerSwitch(char sp) {
 }
 
 void SendToGpsUartCmd(int argc, char *argv[]) {
-	gpsSendBytes((uint8_t *)"Hello GPS!", 11);
+	gpsSendBytes((uint8_t *)"1U2", 3);
 }
 
 

--- a/src/mod/l7_climb_app.c
+++ b/src/mod/l7_climb_app.c
@@ -398,7 +398,7 @@ void SetUtcDateTimeCmd(int argc, char *argv[]) {
 		sec = time % 100;
 
 		// binary cmd
-		TimSetUtc1(year, month, dayOfMonth, hrs, min, sec, true);
+		TimSetUtc1(year, month, dayOfMonth, hrs, min, sec, true, TIM_SYNCSOURCE_DEBUGCMD);
 	}
 }
 

--- a/src/mod/tim/climb_gps.h
+++ b/src/mod/tim/climb_gps.h
@@ -34,6 +34,11 @@ void gpsSendBytes(uint8_t *data, uint8_t len);
 #define EID_GPS_MSGERROR			3
 #define EID_GPS_RXBYTEBUFFERFULL	4
 #define EID_GPS_RXFIELDBUFFERFULL	5
+#define EID_GPS_NMEA_MSG_GSV		6
+#define EID_GPS_NMEA_MSG_GGA		7
+#define EID_GPS_NMEA_MSG_GSA		8
+#define EID_GPS_NMEA_MSG_VTG		9
+#define EID_GPS_NMEA_MSG_RMC		10
 
 
 #endif /* MOD_TIM_CLIMB_GPS_H_ */

--- a/src/mod/tim/climb_gps.h
+++ b/src/mod/tim/climb_gps.h
@@ -34,11 +34,11 @@ void gpsSendBytes(uint8_t *data, uint8_t len);
 #define EID_GPS_MSGERROR			3
 #define EID_GPS_RXBYTEBUFFERFULL	4
 #define EID_GPS_RXFIELDBUFFERFULL	5
-#define EID_GPS_NMEA_MSG_GSV		6
-#define EID_GPS_NMEA_MSG_GGA		7
-#define EID_GPS_NMEA_MSG_GSA		8
-#define EID_GPS_NMEA_MSG_VTG		9
-#define EID_GPS_NMEA_MSG_RMC		10
+#define EID_GPS_SATELLITES_IN_SIGHT	6
+//#define EID_GPS_NMEA_MSG_GGA		7
+//#define EID_GPS_NMEA_MSG_GSA		8
+//#define EID_GPS_NMEA_MSG_VTG		9
+//#define EID_GPS_NMEA_MSG_RMC		10
 
 
 #endif /* MOD_TIM_CLIMB_GPS_H_ */

--- a/src/mod/tim/climb_gps.h
+++ b/src/mod/tim/climb_gps.h
@@ -26,4 +26,14 @@ void gpsMain (void);
 void gpsSendBytes(uint8_t *data, uint8_t len);
 
 
+
+#define MODULE_ID_GPS 				0x04
+
+#define EID_GPS_NMEA_MSG_RAW		1
+#define EID_GPS_CRCERROR			2
+#define EID_GPS_MSGERROR			3
+#define EID_GPS_RXBYTEBUFFERFULL	4
+#define EID_GPS_RXFIELDBUFFERFULL	5
+
+
 #endif /* MOD_TIM_CLIMB_GPS_H_ */

--- a/src/mod/tim/obc_time.h
+++ b/src/mod/tim/obc_time.h
@@ -67,14 +67,25 @@ void timMain (void);
 
 void 	 			timSetResetNumber(uint32_t resetCount);
 uint32_t 			timGetResetNumber(void);
+obc_systime32_t		timGetSystime(void);
 
-void 				TimSetUtc1(uint16_t year, uint8_t month, uint8_t dayOfMonth, uint8_t hour, uint8_t min, uint8_t sec, bool syncRTC);
+void 				TimSetUtc1(uint16_t year, uint8_t month, uint8_t dayOfMonth, uint8_t hour, uint8_t min, uint8_t sec, bool syncRTC, uint8_t syncSource);
+void 				timSyncUtc(uint16_t year, obc_systime32_t systemTime, juliandayfraction utcDateTime, uint8_t syncSource);
 obc_utc_fulltime_t 	timGetUTCTime(void);
+
+juliandayfraction 	timConvertUtcTimeToJdf(uint32_t gpsTime, uint16_t gpsMs);
+juliandayfraction 	timConvertUtcDateToJdf(uint32_t gpsDate);
+
 
 
 // Event defines (Internal defined event structs can be used on debug and com APIs as generic 'Event'.
 #define MODULE_ID_TIME			0x01
 #define EVENT_TIM_INITIALIZED	1
 #define EVENT_TIM_XTALSTARTED	2				// This is only sent when XTAl Error from init 'disappears'.
+#define EVENT_TIM_SYNCHRONIZED	3
+
+#define TIM_SYNCSOURCE_GPS			1
+#define TIM_SYNCSOURCE_DEBUGCMD		2
+#define TIM_SYNCSOURCE_ONBOARDRTC 	3
 
 #endif /* MOD_TIM_OBC_TIME_H_ */


### PR DESCRIPTION
make general SystemTime / reset counter and UTC time available by general routines in obc_time module

add time synchronization by reading and processing  GPS NMEA messages. This code was tested with a [PARALLAX  GPS Module #28504](https://www1.parallax.com/product/28504) connected to UART on Side X- (C).



